### PR TITLE
Show Run/Debug actions as line markers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'se.fortnox.jbehavesinglescenario'
-version '2.4-SNAPSHOT'
+version '2.5-SNAPSHOT'
 
 sourceCompatibility = 1.8
 
@@ -28,11 +28,18 @@ dependencies {
 // See https://github.com/JetBrains/gradle-intellij-plugin/
 intellij {
     version '2019.1.3'
-    updateSinceUntilBuild=false
+    updateSinceUntilBuild = false
+    plugins = [
+            'jbehave-support-plugin:1.53'
+    ]
 }
 
 patchPluginXml {
     changeNotes """
+        <p>2.5:</p>
+        <ul>
+            <li>Run/Debug actions now show as line markers</li>
+        </ul>
         <p>2.4:</p>
         <ul>
             <li>Add support for running scenarios without debugger as well</li>

--- a/src/main/java/se/fortnox/intellij/jbehave/DebugSingleScenarioAction.java
+++ b/src/main/java/se/fortnox/intellij/jbehave/DebugSingleScenarioAction.java
@@ -3,11 +3,25 @@ package se.fortnox.intellij.jbehave;
 import com.intellij.execution.Executor;
 import com.intellij.execution.executors.DefaultDebugExecutor;
 import com.intellij.icons.AllIcons;
+import com.intellij.openapi.vfs.VirtualFile;
+import org.jetbrains.annotations.NotNull;
 
 public class DebugSingleScenarioAction extends JbehaveSingleScenarioAction {
 
 	public DebugSingleScenarioAction() {
-		super("Debug This Scenario", "Debug single scenario", AllIcons.Actions.StartDebugger);
+		super("Debug This Scenario",
+			"Debug single scenario",
+			AllIcons.Actions.StartDebugger,
+			null,
+			null);
+	}
+
+	public DebugSingleScenarioAction(@NotNull String scenarioName, @NotNull VirtualFile storyFile) {
+		super("Debug '" + formatTrimmedScenarioName(scenarioName) + "'",
+			"Debug single scenario",
+			AllIcons.Actions.StartDebugger,
+			scenarioName,
+			storyFile);
 	}
 
 	@Override

--- a/src/main/java/se/fortnox/intellij/jbehave/RunSingleScenarioAction.java
+++ b/src/main/java/se/fortnox/intellij/jbehave/RunSingleScenarioAction.java
@@ -3,10 +3,24 @@ package se.fortnox.intellij.jbehave;
 import com.intellij.execution.Executor;
 import com.intellij.execution.executors.DefaultRunExecutor;
 import com.intellij.icons.AllIcons;
+import com.intellij.openapi.vfs.VirtualFile;
+import org.jetbrains.annotations.NotNull;
 
 public class RunSingleScenarioAction extends JbehaveSingleScenarioAction {
 	public RunSingleScenarioAction() {
-		super("Run This Scenario", "Run single scenario", AllIcons.Actions.Execute);
+		super("Run This Scenario",
+			"Run single scenario",
+			AllIcons.Actions.Execute,
+			null,
+			null);
+	}
+
+	public RunSingleScenarioAction(@NotNull String scenarioName, @NotNull VirtualFile storyFile) {
+		super("Run '" + formatTrimmedScenarioName(scenarioName) + "'",
+			"Run single scenario",
+			AllIcons.Actions.Execute,
+			scenarioName,
+			storyFile);
 	}
 
 	@Override

--- a/src/main/java/se/fortnox/intellij/jbehave/SingleScenarioRunLineMarkerProvider.java
+++ b/src/main/java/se/fortnox/intellij/jbehave/SingleScenarioRunLineMarkerProvider.java
@@ -1,0 +1,37 @@
+package se.fortnox.intellij.jbehave;
+
+import com.intellij.execution.lineMarker.RunLineMarkerContributor;
+import com.intellij.extapi.psi.ASTWrapperPsiElement;
+import com.intellij.icons.AllIcons;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.impl.source.tree.LeafPsiElement;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class SingleScenarioRunLineMarkerProvider extends RunLineMarkerContributor {
+
+	@Nullable
+	@Override
+	public Info getInfo(@NotNull PsiElement element) {
+		PsiElement parent = element.getParent();
+		if (parent instanceof ASTWrapperPsiElement
+			&& element instanceof LeafPsiElement
+			&& element.getText().startsWith(JbehaveSingleScenarioAction.SCENARIO_PREFIX)
+		) {
+			String      scenario  = JbehaveSingleScenarioAction.findScenario(parent.getText(), 0);
+			VirtualFile storyFile = element.getContainingFile().getVirtualFile();
+
+			if (scenario != null) {
+				return new Info(
+					AllIcons.Actions.Execute,
+					null,
+					new RunSingleScenarioAction(scenario, storyFile),
+					new DebugSingleScenarioAction(scenario, storyFile)
+				);
+			}
+		}
+
+		return null;
+	}
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -6,6 +6,10 @@
 	<description>Right click in a scenario of a .story file to run or debug it.</description>
 
 	<extensions defaultExtensionNs="com.intellij">
+		<runLineMarkerContributor
+				language="Story"
+				implementationClass="se.fortnox.intellij.jbehave.SingleScenarioRunLineMarkerProvider"
+		/>
 	</extensions>
 
 	<actions>


### PR DESCRIPTION
- Example:
![image](https://user-images.githubusercontent.com/123355/106182254-dd45d380-619e-11eb-9662-7233c5ff58f3.png)

- The change to `getStoryClass` attempts to find the relevant class regardless of implementation language.
